### PR TITLE
Fix CUDA compilation error: replace structured bindings in kernel launch code

### DIFF
--- a/src/layers/extensions/inference/common.h
+++ b/src/layers/extensions/inference/common.h
@@ -268,8 +268,12 @@ __forceinline__ __device__ T reciprocal(const T& a)
     return make_vec4(reciprocal(a.x), reciprocal(a.y), reciprocal(a.z), reciprocal(a.w));
 }
 
-template <typename T1, typename T2>
-__forceinline__ __device__ bool4 operator>(const T1& a, const T2& b)
+__forceinline__ __device__ bool4 operator>(const float4& a, const float b)
+{
+    return make_vec4(a.x > b, a.y > b, a.z > b, a.w > b);
+}
+
+__forceinline__ __device__ bool4 operator>(const Half4& a, const c10::Half& b)
 {
     return make_vec4(a.x > b, a.y > b, a.z > b, a.w > b);
 }

--- a/src/layers/extensions/inference/kernel.cu
+++ b/src/layers/extensions/inference/kernel.cu
@@ -94,9 +94,16 @@ process_with_mask_dispatcher(torch::Tensor& y_res, torch::Tensor& y_q, torch::Te
                              const torch::Tensor& scales, const torch::Tensor& means,
                              const torch::Tensor& mask, const float force_zero_thres)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(y);
-    const bool force_zero = force_zero_thres > 0.f;
+    const auto launch_info = get_kernel_launch_info<vec_t>(y);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
 
+    const bool force_zero = force_zero_thres > 0.f;
     auto launch_kernel = [&](auto in_v) {
         using in_t = decltype(in_v);
         if (force_zero) {
@@ -160,7 +167,15 @@ template <typename scalar_t, typename vec_t>
 __forceinline__ void combine_for_reading_2x_dispatcher(torch::Tensor& out, const torch::Tensor& x,
                                                        const torch::Tensor& mask)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x, 2);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x,2);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+    
     if (useVec) {
         combine_for_reading_2x_kernel<vec_t><<<gridDim, blockDim, 0, stream>>>(out, x, mask, N);
     } else {
@@ -202,7 +217,15 @@ template <typename scalar_t, typename vec_t>
 __forceinline__ void restore_y_2x_dispatcher(torch::Tensor& out, const torch::Tensor& y,
                                              const torch::Tensor& means, const torch::Tensor& mask)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(y);
+    const auto launch_info = get_kernel_launch_info<vec_t>(y);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+    
     if (useVec) {
         restore_y_2x_kernel<vec_t><<<gridDim, blockDim, 0, stream>>>(out, y, means, mask, N);
     } else {
@@ -255,7 +278,15 @@ template <typename scalar_t, typename vec_t>
 __forceinline__ void restore_y_4x_dispatcher(torch::Tensor& out, const torch::Tensor& y,
                                              const torch::Tensor& means, const torch::Tensor& mask)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(y);
+    const auto launch_info = get_kernel_launch_info<vec_t>(y);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+    
     if (useVec) {
         restore_y_4x_kernel<vec_t><<<gridDim, blockDim, 0, stream>>>(out, y, means, mask, N);
     } else {
@@ -312,7 +343,13 @@ build_index_dec_dispatcher(torch::Tensor& out, torch::optional<torch::Tensor>& c
                            const scalar_t scale_max, const scalar_t log_scale_min,
                            const scalar_t log_step_recip, const scalar_t skip_thres)
 {
-    auto [blockDim, gridDim, stream, useVec, N] = get_kernel_launch_info_flatten<vec_t>(scales);
+    const auto launch_info = get_kernel_launch_info_flatten<vec_t>(scales);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const int N = std::get<4>(launch_info);
+    
     const bool with_cond = static_cast<float>(skip_thres) > 0.f;
 
     auto launch_kernel = [&](auto in_v, auto out_v, auto cond_out_v) {
@@ -380,7 +417,13 @@ __forceinline__ void build_index_enc_dispatcher(
     const torch::Tensor& scales, const scalar_t scale_min, const scalar_t scale_max,
     const scalar_t log_scale_min, const scalar_t log_step_recip, const scalar_t skip_thres)
 {
-    auto [blockDim, gridDim, stream, useVec, N] = get_kernel_launch_info_flatten<vec_t>(scales);
+    const auto launch_info = get_kernel_launch_info_flatten<vec_t>(scales);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const int N = std::get<4>(launch_info);
+    
     const bool with_cond = static_cast<float>(skip_thres) > 0.f;
 
     auto launch_kernel = [&](auto in_v, auto out_v, auto cond_out_v) {
@@ -458,7 +501,15 @@ __global__ void bias_wsilu_kernel(GPUTensor1D<vec_t> x, const GPUTensor1D<scalar
 template <typename scalar_t, typename vec_t>
 __forceinline__ void bias_wsilu_dispatcher(torch::Tensor& x, const torch::Tensor& bias)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+    
     if (useVec) {
         if (biasSafe) {
             bias_wsilu_kernel<scalar_t, vec_t, true><<<gridDim, blockDim, 0, stream>>>(x, bias, N, HW);
@@ -507,7 +558,15 @@ __forceinline__ void bias_shortcut_dispatcher(torch::Tensor& x, const torch::Ten
                                               const torch::Tensor& quant_step,
                                               const torch::Tensor& shortcut)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+        
     if (useVec) {
         if (biasSafe) {
             bias_shortcut_kernel<scalar_t, vec_t, true, with_shortcut, with_quant>
@@ -563,7 +622,15 @@ __forceinline__ void bias_shortcut_no_inplace_dispatcher(torch::Tensor& out, con
                                                          const torch::Tensor& bias,
                                                          const torch::Tensor& shortcut)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+        
     if (useVec) {
         if (biasSafe) {
             bias_shortcut_no_inplace_kernel<scalar_t, vec_t, true>
@@ -608,7 +675,15 @@ template <typename scalar_t, typename vec_t>
 __forceinline__ void bias_shortcut_2_dispatcher(torch::Tensor& x, const torch::Tensor& bias,
                                                 torch::Tensor& shortcut)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+
     if (useVec) {
         if (biasSafe) {
             bias_shortcut_2_kernel<scalar_t, vec_t, true>
@@ -667,7 +742,15 @@ __global__ void bias_wsilu_chunk_add_kernel(GPUTensor1D<vec_t> x, const GPUTenso
 template <typename scalar_t, typename vec_t>
 __forceinline__ void bias_wsilu_chunk_add_dispatcher(torch::Tensor& x, const torch::Tensor& bias)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x, 2);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x, 2);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+    
     if (useVec) {
         if (biasSafe) {
             bias_wsilu_chunk_add_kernel<scalar_t, vec_t, true>
@@ -843,7 +926,15 @@ __global__ void round_and_to_int8_kernel(GPUTensor1D<vec_t1> z, GPUTensor1D<vec_
 template <typename scalar_t, typename vec_t>
 __forceinline__ void round_and_to_int8_dispatcher(torch::Tensor& z, torch::Tensor& z_int8)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(z);
+    const auto launch_info = get_kernel_launch_info<vec_t>(z);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+    
     if (useVec) {
         round_and_to_int8_kernel<scalar_t, vec_t, char4>
             <<<gridDim, blockDim, 0, stream>>>(z, z_int8, N);
@@ -887,7 +978,15 @@ __forceinline__ void clamp_reciprocal_with_quant_dispatcher(torch::Tensor& q_dec
                                                             const torch::Tensor& q_dec,
                                                             torch::Tensor& y, const float min_val)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(q_dec);
+    const auto launch_info = get_kernel_launch_info<vec_t>(q_dec);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+
     if (useVec) {
         clamp_reciprocal_with_quant_kernel<scalar_t, vec_t><<<gridDim, blockDim, 0, stream>>>(
             q_dec_clamp, q_dec, y, static_cast<scalar_t>(min_val), N);
@@ -929,7 +1028,15 @@ template <typename scalar_t, typename vec_t>
 __forceinline__ void add_and_multiply_dispatcher(torch::Tensor& x0, const torch::Tensor& x1,
                                                  const torch::Tensor& q)
 {
-    auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] = get_kernel_launch_info<vec_t>(x0);
+    const auto launch_info = get_kernel_launch_info<vec_t>(x0);
+    const dim3& blockDim = std::get<0>(launch_info);
+    const dim3& gridDim = std::get<1>(launch_info);
+    const at::cuda::CUDAStream& stream = std::get<2>(launch_info);
+    const bool useVec = std::get<3>(launch_info);
+    const bool biasSafe = std::get<4>(launch_info);
+    const int N = std::get<5>(launch_info);
+    const int HW = std::get<6>(launch_info);
+
     if (useVec) {
         add_and_multiply_kernel<vec_t><<<gridDim, blockDim, 0, stream>>>(x0, x1, q, N);
     } else {


### PR DESCRIPTION
I treated this as a small bug fix rather than a feature addition, so I submitted a PR directly without an issue.
Apologies if that’s against the usual workflow. And I’ll be glad to open an issue if preferred.

## Summary

This PR fixes two CUDA compilation issues in the inference extensions:

1. Removes C++17 structured bindings from kernel launch parameter handling (`kernel.cu`) to avoid nvcc capture errors. (Relevant Issue : #88) 
2. Replaces overly-generic comparison operator templates in `common.h` with type-specific overloads, preventing invalid instantiation with non-vector types (e.g., `std::atomic<int>`).

These changes significantly improve compatibility with nvcc’s partial C++17 support and ensure the CUDA extensions build reliably across different environments.


---

## 1. Remove structured bindings from kernel launch code (`kernel.cu`)

### Problem

`kernel.cu` used structured bindings:

```cpp
auto [blockDim, gridDim, stream, useVec, biasSafe, N, HW] =
    get_kernel_launch_info<vec_t>(y);
```
`nvcc` has incomplete support for capturing structured-binding variables inside lambda functions or kernel-launch expressions, and this frequently leads to compilation errors in CUDA extension code.

In my case, nvcc fails with: [error_log_1.txt](https://github.com/user-attachments/files/24111110/error_log_1.txt)
```
error: structured binding cannot be captured
```



This is due to incomplete support for capturing structured bindings in nvcc's C++17 implementation.

### Fix

Structured bindings are replaced with explicit tuple unpacking:

```cpp
const auto launch_info = get_kernel_launch_info<vec_t>(y);
const dim3& blockDim = std::get<0>(launch_info);
const dim3& gridDim  = std::get<1>(launch_info);
const auto& stream   = std::get<2>(launch_info);
const bool  useVec   = std::get<3>(launch_info);
const bool  biasSafe = std::get<4>(launch_info);
const int   N        = std::get<5>(launch_info);
const int   HW       = std::get<6>(launch_info);
```
This avoids the nvcc limitation while preserving identical functionality.

## 2. Fix comparison operator template in `common.h`

### Problem

`common.h` defined a generic comparison operator template:
```cpp
template <typename T1, typename T2>
__forceinline__ __device__ bool4 operator>(const T1& a, const T2& b) {
    return make_vec4(a.x > b, a.y > b, a.z > b, a.w > b);
}
```

Because this template matched any type, nvcc attempted to instantiate it for types that do not contain `.x/.y/.z/.w,` such as:
- std::atomic<int>
- other pybind11 internal types

This produced errors like: [error_log_2.txt](https://github.com/user-attachments/files/24111158/error_log_2.txt)

```cpp
error: class "std::atomic<int>" has no member "x"
```

### Fix
The generic template is removed and replaced with explicit overloads for supported vector types:
```cpp
__forceinline__ __device__ bool4 operator>(const float4& a, const float b) {
    return make_vec4(a.x > b, a.y > b, a.z > b, a.w > b);
}

__forceinline__ __device__ bool4 operator>(const Half4& a, const c10::Half& b) {
    return make_vec4(a.x > b, a.y > b, a.z > b, a.w > b);
}
```
This prevents invalid instantiation and ensures correct operator behavior.

## Safety
- No functional or numerical logic was changed.
- Kernel launch behavior is identical (same block/grid dimensions, streams, flags).
- The operator overload fix only eliminates unintended template matches.
- Execution results (encode/decode paths) match prior behavior.

## Testing 
- my env: [environment.txt](https://github.com/user-attachments/files/24111179/environment.txt)
- successful compiling: [successful.txt](https://github.com/user-attachments/files/24111194/successful.txt)

## closing
I appreciate your time reviewing my PR. Thanks
