### PR TITLE
CUDA inference extension build by explicitly including torch/nn/functional.h

### DIFF
--- a/src/layers/extensions/inference/impl.cpp
+++ b/src/layers/extensions/inference/impl.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include <torch/nn/functional.h>
 #include "def.h"
 namespace F = torch::nn::functional;
 


### PR DESCRIPTION
This PR adds an explicit `#include <torch/nn/functional.h>` in `src/layers/extensions/inference/impl.cpp`.

`impl.cpp` uses `torch::nn::functional` but currently relies on transitive includes. On my environment, the inference extension build required including this header explicitly.

This is a build-only change and does not modify runtime behavior or model outputs.
